### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   id = "paketo-buildpacks/cpython"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
