### PR TITLE
Uses `PYTHONPYCACHEPREFIX` to control where `__pycache__` goes

### DIFF
--- a/build.go
+++ b/build.go
@@ -145,7 +145,8 @@ func Build(dependencies DependencyManager, sbomGenerator SBOMGenerator, logger s
 			DepKey: dependency.SHA256,
 		}
 
-		cpythonLayer.SharedEnv.Override("PYTHONPATH", cpythonLayer.Path)
+		cpythonLayer.SharedEnv.Default("PYTHONPATH", cpythonLayer.Path)
+		cpythonLayer.SharedEnv.Default("PYTHONPYCACHEPREFIX", "$HOME/.pycache")
 
 		logger.Break()
 		logger.Process("Configuring environment")

--- a/build_test.go
+++ b/build_test.go
@@ -118,7 +118,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.Path).To(Equal(filepath.Join(layersDir, "cpython")))
 
 		Expect(layer.SharedEnv).To(Equal(packit.Environment{
-			"PYTHONPATH.override": filepath.Join(layersDir, "cpython"),
+			"PYTHONPATH.default":          filepath.Join(layersDir, "cpython"),
+			"PYTHONPYCACHEPREFIX.default": "$HOME/.pycache",
 		}))
 		Expect(layer.BuildEnv).To(BeEmpty())
 		Expect(layer.LaunchEnv).To(BeEmpty())

--- a/integration/buildpack_yml_test.go
+++ b/integration/buildpack_yml_test.go
@@ -89,7 +89,8 @@ func testBuildpackYAML(t *testing.T, context spec.G, it spec.S) {
 			))
 			Expect(logs).To(ContainLines(
 				"  Configuring environment",
-				MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
+				fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
 			))
 		})
 	})

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -84,7 +84,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			))
 			Expect(logs).To(ContainLines(
 				"  Configuring environment",
-				MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
+				fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
 			))
 		})
 
@@ -217,7 +218,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(logs).To(ContainLines(
 					"  Configuring environment",
-					MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
+					fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+					`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
 				))
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Python 3.x will precompile bytecode artifacts (`*.pyc` files) when these libraries are loaded. These files appear within `__pycache__` directories alongside their source code. For libraries provided by the stdlib, these directories will be created or updated within the `cpython` layer since the source is located there. Ultimately, this means that loading Python code will result in the interpreter modifying the `cpython` layer after it has been created, thus creating non-reproducible builds.

There are a couple of options to prevent this layer modification from happening:
1. Set [`PYTHONDONTWRITEBYTECODE`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE) which will ensure these artifacts are never generated.
2. Set [`PYTHONPYCACHEPREFIX`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPYCACHEPREFIX) which will control where these artifacts appear on the filesystem.

I've chosen to set `PYTHONPYCACHEPREFIX` as it still allows any benefit these files may provide while ensuring we aren't inadvertently modifying the `cpython` layer.

Additionally, I've changed the level at which we apply the `PYTHONPATH` environment variable to `Default` to align with [RFC0019](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0019-buildpack-set-env-vars-defaults.md).

## Use Cases
<!-- An explanation of the use cases your change enables -->
Resolves https://github.com/paketo-buildpacks/cpython/issues/317

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
