### PR TITLE
Use exec.d to set PYTHONPYCACHEPREFIX

### DIFF
--- a/build.go
+++ b/build.go
@@ -137,7 +137,7 @@ func Build(dependencies DependencyManager, sbomGenerator SBOMGenerator, logger s
 		}
 
 		cpythonLayer.SharedEnv.Default("PYTHONPATH", cpythonLayer.Path)
-		cpythonLayer.SharedEnv.Default("PYTHONPYCACHEPREFIX", "$HOME/.pycache")
+		cpythonLayer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "env")}
 
 		logger.Break()
 

--- a/build_test.go
+++ b/build_test.go
@@ -117,8 +117,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.Path).To(Equal(filepath.Join(layersDir, "cpython")))
 
 		Expect(layer.SharedEnv).To(Equal(packit.Environment{
-			"PYTHONPATH.default":          filepath.Join(layersDir, "cpython"),
-			"PYTHONPYCACHEPREFIX.default": "$HOME/.pycache",
+			"PYTHONPATH.default": filepath.Join(layersDir, "cpython"),
 		}))
 		Expect(layer.BuildEnv).To(BeEmpty())
 		Expect(layer.LaunchEnv).To(BeEmpty())
@@ -130,6 +129,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(layer.Metadata).To(Equal(map[string]interface{}{
 			"dependency-sha": "python-dependency-sha",
+		}))
+
+		Expect(layer.ExecD).To(Equal([]string{
+			filepath.Join(cnbDir, "bin", "env"),
 		}))
 
 		Expect(layer.SBOM.Formats()).To(Equal([]packit.SBOMFormat{

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -10,7 +10,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/cpython/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
+  include-files = ["bin/run", "bin/build", "bin/detect", "bin/env", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
     python = "3.9.x"

--- a/cmd/env/internal/init_test.go
+++ b/cmd/env/internal/init_test.go
@@ -1,0 +1,14 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnitEnv(t *testing.T) {
+	suite := spec.New("cmd/env/internal", spec.Report(report.Terminal{}))
+	suite("Run", testRun)
+	suite.Run(t)
+}

--- a/cmd/env/internal/run.go
+++ b/cmd/env/internal/run.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Run will write a TOML environment definition to the output io.Writer with
+// the following rules:
+// 1. If $PYTHONPYCACHEPREFIX is set, do nothing
+// 2. If $PYTHONPYCACHEPREFIX is unset, set it to the expanded value of
+//    $HOME/.pycache
+func Run(env []string, output io.Writer) error {
+	var home string
+	for _, v := range env {
+		if strings.HasPrefix(v, "HOME=") {
+			home = strings.TrimPrefix(v, "HOME=")
+		}
+
+		if strings.HasPrefix(v, "PYTHONPYCACHEPREFIX=") {
+			return nil
+		}
+	}
+
+	err := toml.NewEncoder(output).Encode(map[string]string{
+		"PYTHONPYCACHEPREFIX": filepath.Join(home, ".pycache"),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/env/internal/run_test.go
+++ b/cmd/env/internal/run_test.go
@@ -1,0 +1,61 @@
+package internal_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/paketo-buildpacks/cpython/cmd/env/internal"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/packit/v2/matchers"
+)
+
+func testRun(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("when $PYTHONPYCACHEPREFIX is not set", func() {
+		it("sets it to $HOME/.pycache", func() {
+			buffer := bytes.NewBuffer(nil)
+			err := internal.Run([]string{"HOME=/some-home"}, buffer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(buffer.String()).To(MatchTOML(`
+				PYTHONPYCACHEPREFIX = "/some-home/.pycache"
+			`))
+		})
+	})
+
+	context("when $PYTHONPYCACHEPREFIX is already set", func() {
+		it("preserves the existing value", func() {
+			buffer := bytes.NewBuffer(nil)
+			err := internal.Run([]string{
+				"HOME=/some-home",
+				"PYTHONPYCACHEPREFIX=/other-home/.pycache",
+			}, buffer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(buffer.String()).To(BeEmpty())
+		})
+	})
+
+	context("failure cases", func() {
+		context("when the output cannot be written to", func() {
+			var file *os.File
+
+			it.Before(func() {
+				file, err := os.CreateTemp("", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(file.Close()).To(Succeed())
+				Expect(os.Remove(file.Name())).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				err := internal.Run([]string{"HOME=/some-home"}, file)
+				Expect(err).To(MatchError("invalid argument"))
+			})
+		})
+	})
+}

--- a/cmd/env/main.go
+++ b/cmd/env/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/paketo-buildpacks/cpython/cmd/env/internal"
+)
+
+// env will set environment variables that are dynamically defined at runtime
+func main() {
+	err := internal.Run(os.Environ(), os.NewFile(3, "/dev/fd/3"))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -67,7 +67,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
-			Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
+			Eventually(container).Should(Serve(SatisfyAll(
+				ContainSubstring("hello world"),
+				ContainSubstring("PYTHONPYCACHEPREFIX=/home/cnb/.pycache"),
+			)).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
@@ -84,12 +87,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			))
 			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
-				fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
-				`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
+				fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				"",
 				"  Configuring launch environment",
-				fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
-				`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
+				fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
 		})
 
@@ -218,12 +219,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(logs).To(ContainLines(
 					"  Configuring build environment",
-					fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
-					`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
+					fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 					"",
 					"  Configuring launch environment",
-					fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
-					`    PYTHONPYCACHEPREFIX -> "$HOME/.pycache"`,
+					fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				))
 			})
 		})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -48,6 +48,7 @@ func TestIntegration(t *testing.T) {
 	// Do not truncate Gomega matcher output
 	// The buildpack output text can be large and we often want to see all of it.
 	format.MaxLength = 0
+	SetDefaultEventuallyTimeout(30 * time.Second)
 
 	Expect := NewWithT(t).Expect
 
@@ -82,8 +83,6 @@ func TestIntegration(t *testing.T) {
 	settings.Buildpacks.BuildPlan.Online, err = buildpackStore.Get.
 		Execute(settings.Config.BuildPlan)
 	Expect(err).NotTo(HaveOccurred())
-
-	SetDefaultEventuallyTimeout(5 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)

--- a/integration/testdata/default_app/server.py
+++ b/integration/testdata/default_app/server.py
@@ -3,16 +3,19 @@ import os
 
 class Server(BaseHTTPRequestHandler):
   def do_GET(self):
-        self.send_response(200)
-        self.send_header("Content-type","text/plain")
-        self.end_headers()
-        self.wfile.write(bytes("hello world", "utf8"))
-        return
+    self.send_response(200)
+    self.send_header("Content-type","text/plain")
+    self.end_headers()
+
+    self.wfile.write(bytes("hello world", "utf8"))
+
+    prefix = os.getenv("PYTHONPYCACHEPREFIX")
+    self.wfile.write(bytes(f'PYTHONPYCACHEPREFIX={prefix}', "utf8"))
+
   def do_HEAD(self):
-        self.send_response(200)
-        self.send_header("Content-type","text/plain")
-        self.end_headers()
-        return
+    self.send_response(200)
+    self.send_header("Content-type","text/plain")
+    self.end_headers()
 
 port = int(os.getenv("PORT", "8080"))
 server_address = ("", port)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We will need to use an `exec.d` binary to set the `PYTHONPYCACHEPREFIX` with the dynamic value for `$HOME`. This is because the values placed into the normal environment variable file API are not interpolated/expanded before the process is executed.

The original implementation of this feature (https://github.com/paketo-buildpacks/cpython/pull/340) assumed this interpolation/expansion incorrectly and the bug was being resolved with a surprising and unexpected behavior. Specifically, the `__pycache__` contents we being written to `/workspace/'$HOME'/.pycache`.

This resolved the immediate bug in that these files were no longer being written into what should have been a read-only layer, but then caused another bug in that it would easily crash a `watchexec` process that was restarting a process when there were modifications to the `/workspace` directory.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Enables https://github.com/paketo-buildpacks/python/pull/478 to be merged.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
