### PR TITLE
Support Jammy stacks

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -123,7 +123,7 @@ api = "0.7"
     sha256 = "e8027469448fc94c49140b3de122a2a5b8437c04ca47f72ee4d38e1e6d68a540"
     source = "https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tgz"
     source_sha256 = "18f57182a2de3b0be76dfc39fdcfd28156bb6dd23e5f08696f7492e9e3d0bf2d"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/python/python_3.10.5_linux_x64_bionic_e8027469.tgz"
     version = "3.10.5"
 
@@ -149,6 +149,9 @@ api = "0.7"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"
 
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/integration.json
+++ b/integration.json
@@ -1,3 +1,7 @@
 {
+  "builders": [
+    "index.docker.io/paketobuildpacks/builder:buildpackless-base",
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+  ],
   "build-plan": "github.com/paketo-community/build-plan"
 }

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -47,52 +47,55 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
 		})
 
-		it("builds with the defaults", func() {
-			var err error
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithPullPolicy("never").
-				WithBuildpacks(
-					settings.Buildpacks.Cpython.Online,
-					settings.Buildpacks.BuildPlan.Online,
-				).
-				Execute(name, filepath.Join("testdata", "default_app"))
-			Expect(err).ToNot(HaveOccurred(), logs.String)
+		for _, builder := range settings.Config.Builders {
+			it(fmt.Sprintf("builds on %s with the defaults", builder), func() {
+				var err error
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						settings.Buildpacks.Cpython.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					).
+					WithBuilder(builder).
+					Execute(name, filepath.Join("testdata", "default_app"))
+				Expect(err).ToNot(HaveOccurred(), logs.String)
 
-			container, err = docker.Container.Run.
-				WithCommand("python3 server.py").
-				WithEnv(map[string]string{"PORT": "8080"}).
-				WithPublish("8080").
-				Execute(image.ID)
-			Expect(err).ToNot(HaveOccurred())
+				container, err = docker.Container.Run.
+					WithCommand("python3 server.py").
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					Execute(image.ID)
+				Expect(err).ToNot(HaveOccurred())
 
-			Eventually(container).Should(BeAvailable())
-			Eventually(container).Should(Serve(SatisfyAll(
-				ContainSubstring("hello world"),
-				ContainSubstring("PYTHONPYCACHEPREFIX=/home/cnb/.pycache"),
-			)).OnPort(8080))
+				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(SatisfyAll(
+					ContainSubstring("hello world"),
+					ContainSubstring("PYTHONPYCACHEPREFIX=/home/cnb/.pycache"),
+				)).OnPort(8080))
 
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
-				"  Resolving CPython version",
-				"    Candidate version sources (in priority order):",
-				"      <unknown> -> \"\"",
-				"",
-				MatchRegexp(`    Selected CPython version \(using <unknown>\): 3\.\d+\.\d+`),
-			))
-			Expect(logs).To(ContainLines(
-				"  Executing build process",
-				MatchRegexp(`    Installing CPython 3\.\d+\.\d+`),
-				MatchRegexp(`      Completed in \d+\.\d+`),
-			))
-			Expect(logs).To(ContainLines(
-				"  Configuring build environment",
-				fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
-				"",
-				"  Configuring launch environment",
-				fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
-			))
-		})
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+					"  Resolving CPython version",
+					"    Candidate version sources (in priority order):",
+					"      <unknown> -> \"\"",
+					"",
+					MatchRegexp(`    Selected CPython version \(using <unknown>\): 3\.\d+\.\d+`),
+				))
+				Expect(logs).To(ContainLines(
+					"  Executing build process",
+					MatchRegexp(`    Installing CPython 3\.\d+\.\d+`),
+					MatchRegexp(`      Completed in \d+\.\d+`),
+				))
+				Expect(logs).To(ContainLines(
+					"  Configuring build environment",
+					fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+					"",
+					"  Configuring launch environment",
+					fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				))
+			})
+		}
 
 		context("validating SBOM", func() {
 			var (

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -40,7 +40,8 @@ var settings struct {
 	}
 
 	Config struct {
-		BuildPlan string `json:"build-plan"`
+		BuildPlan string   `json:"build-plan"`
+		Builders  []string `json:"builders"`
 	}
 }
 


### PR DESCRIPTION
Indicate that `Jammy` is a supported stack. Use `Jammy` in one of the integration tests.

`dep-server` automation will add `io.buildpacks.stacks.jammy` to the dependency metadata starting with `>=3.10.5` once https://github.com/paketo-buildpacks/dep-server/pull/189 is merged.

See paketo-buildpacks/python#490 for context.