### PR TITLE
Bump default version of CPython to `3.10.*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ that is installed. (Available versions can be found in the
 
 #### `pack build` flag
 ```shell
-pack build my-app --env BP_CPYTHON_VERSION=3.8.*
+pack build my-app --env BP_CPYTHON_VERSION=3.10.*
 ```
 
 #### In a [`project.toml`](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
@@ -35,7 +35,7 @@ pack build my-app --env BP_CPYTHON_VERSION=3.8.*
 [build]
   [[build.env]]
     name = 'BP_CPYTHON_VERSION'
-    value = '3.8.*' # any valid semver constraints (e.g. 3.8.7, 3.*) are acceptable
+    value = '3.10.*' # any valid semver constraints (e.g. 3.10.2, 3.*) are acceptable
 ```
 
 ## Integration
@@ -51,15 +51,17 @@ file that looks like the following:
   # part of the public API for the buildpack and will not change without a plan
   # for deprecation.
   name = "cpython"
-  # The version of the CPython dependency is not required. In the case it
-  # is not specified, the buildpack will provide the default version, which can
-  # be seen in the buildpack.toml file.
-  # If you wish to request a specific version, the buildpack supports
-  # specifying a semver constraint in the form of "3.*", "3.8.*", or even
-  # "3.8.2".
-  version = "3.8.2"
+
   # The CPython buildpack supports some non-required metadata options.
   [requires.metadata]
+
+    # The version of the CPython dependency is not required. In the case it
+    # is not specified, the buildpack will provide the default version, which can
+    # be seen in the buildpack.toml file.
+    # If you wish to request a specific version, the buildpack supports
+    # specifying a semver constraint in the form of "3.*", "3.10.*", or even
+    # "3.10.2".
+    version = "3.10.2"
 
     # Setting the build flag to true will ensure that the CPython
     # depdendency is available on the $PATH for subsequent buildpacks during

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -13,7 +13,7 @@ api = "0.7"
   include-files = ["bin/run", "bin/build", "bin/detect", "bin/env", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
-    python = "3.9.x"
+    python = "3.10.x"
 
   [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.7.12:*:*:*:*:*:*:*"

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -184,7 +184,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithEnv(map[string]string{
-						"BP_CPYTHON_VERSION": "3.8.*",
+						"BP_CPYTHON_VERSION": "3.9.*",
 					}).
 					Execute(name, filepath.Join("testdata", "default_app"))
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -203,17 +203,17 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 					"  Resolving CPython version",
 					"    Candidate version sources (in priority order):",
-					`      BP_CPYTHON_VERSION -> "3.8.*"`,
+					`      BP_CPYTHON_VERSION -> "3.9.*"`,
 					`      <unknown>          -> ""`,
 				))
 
 				Expect(logs).To(ContainLines(
-					MatchRegexp(`   Selected CPython version \(using BP_CPYTHON_VERSION\): 3\.8\.\d+`),
+					MatchRegexp(`   Selected CPython version \(using BP_CPYTHON_VERSION\): 3\.9\.\d+`),
 				))
 
 				Expect(logs).To(ContainLines(
 					"  Executing build process",
-					MatchRegexp(`    Installing CPython 3\.8\.\d+`),
+					MatchRegexp(`    Installing CPython 3\.9\.\d+`),
 					MatchRegexp(`      Completed in \d+\.\d+`),
 				))
 


### PR DESCRIPTION
## Summary
Bump default version of CPython to `3.10.*`

## Use Cases
In preparation for Jammy support (see #360), let's default to using the earliest Python version supported by Jammy [ref](https://github.com/paketo-buildpacks/dep-server/pull/189#issuecomment-1189094725).

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
