### PR TITLE
Support Jammy Stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -203,4 +203,7 @@ api = "0.7"
   id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
+  id = "io.buildpacks.stacks.jammy"
+
+[[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/integration.json
+++ b/integration.json
@@ -1,6 +1,7 @@
 {
   "builders": [
-    "index.docker.io/paketobuildpacks/builder:buildpackless-base"
+    "index.docker.io/paketobuildpacks/builder:buildpackless-base",
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
   ],
   "build-plan": "github.com/paketo-community/build-plan"
 }


### PR DESCRIPTION
This will fail because several integration tests request Python `3.9.*`, for which we do not have compiled dependencies. 

Will seek to resolve this with @paketo-buildpacks/python-maintainers ASAP, just wanted this PR out in public and running.