### PR TITLE
Add support all stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ The `BP_CPYTHON_VERSION` variable allows you to specify the version of CPython
 that is installed. (Available versions can be found in the
 [buildpack.toml](./buildpack.toml).)
 
+### `BP_CPYTHON_CONFIGURE_FLAGS`
+The `BP_CPYTHON_CONFIGURE_FLAGS` variable allows you to specify configure flags
+when python is installed from source. This is only applicable when using custom 
+stacks. Paketo stacks such as `io.buildpacks.stacks.bionic` install pre-built binaries. 
+
+* The format is space-separated strings, and they are passed directly to the `cpython` `./configure` process , e.g. `--foo --bar=baz`.
+* See [python documentation](https://docs.python.org/3/using/configure.html) for supported flags.
+* Default flags if not specified: `--enable-optimizations --with-ensurepip`
+* Note that default flags are overridden if you specify this environment variable,
+which means you almost certainly want to include the defaults along with any custom flags.
+  - e.g. `--enable-optimizations --with-ensurepip --foo --bar=baz`
+
+### `BP_LOG_LEVEL`
+When using custom stacks that install python from source setting `BP_LOG_LEVEL=DEBUG`
+shows the commands and outputs run to build python.
+
 #### `pack build` flag
 ```shell
 pack build my-app --env BP_CPYTHON_VERSION=3.10.*
@@ -91,3 +107,7 @@ To run the unit and integration tests for this buildpack:
 ```
 $ ./scripts/unit.sh && ./scripts/integration.sh
 ```
+
+## Compatibility
+
+This buildpack is currently only supported on linux distributions.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,6 +28,20 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://deps.paketo.io/python/python_3.7.13_linux_x64_bionic_8dc9323f.tgz"
     version = "3.7.13"
+  
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.7.13:*:*:*:*:*:*:*"
+    deprecation_date = "2023-06-27T00:00:00Z"
+    id = "python"
+    licenses = ["CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.7.13?checksum=e405417f50984bc5870c7e7a9f9aeb93e9d270f5ac67f667a0cd3a09439682b5&download_url=https://www.python.org/ftp/python/3.7.13/Python-3.7.13.tgz"
+    sha256 = "e405417f50984bc5870c7e7a9f9aeb93e9d270f5ac67f667a0cd3a09439682b5"
+    source = "https://www.python.org/ftp/python/3.7.13/Python-3.7.13.tgz"
+    source_sha256 = "e405417f50984bc5870c7e7a9f9aeb93e9d270f5ac67f667a0cd3a09439682b5"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.7.13/Python-3.7.13.tgz"
+    version = "3.7.13"
 
   [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.7.14:*:*:*:*:*:*:*"
@@ -42,7 +56,21 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://deps.paketo.io/python/python_3.7.14_linux_x64_bionic_555e735d.tgz"
     version = "3.7.14"
-
+  
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.7.14:*:*:*:*:*:*:*"
+    deprecation_date = "2023-06-27T00:00:00Z"
+    id = "python"
+    licenses = ["CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.7.14?checksum=82b2abf8978caa61a9011d166eede831b32de9cbebc0db8162900fa23437b709&download_url=https://www.python.org/ftp/python/3.7.14/Python-3.7.14.tgz"
+    sha256 = "82b2abf8978caa61a9011d166eede831b32de9cbebc0db8162900fa23437b709"
+    source = "https://www.python.org/ftp/python/3.7.14/Python-3.7.14.tgz"
+    source_sha256 = "82b2abf8978caa61a9011d166eede831b32de9cbebc0db8162900fa23437b709"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.7.14/Python-3.7.14.tgz"
+    version = "3.7.14"
+  
   [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.8.13:*:*:*:*:*:*:*"
     deprecation_date = "2024-10-01T00:00:00Z"
@@ -56,7 +84,21 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://deps.paketo.io/python/python_3.8.13_linux_x64_bionic_78e0d6ac.tgz"
     version = "3.8.13"
-
+  
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.8.13:*:*:*:*:*:*:*"
+    deprecation_date = "2024-10-01T00:00:00Z"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.8.13?checksum=903b92d76354366b1d9c4434d0c81643345cef87c1600adfa36095d7b00eede4&download_url=https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tgz"
+    sha256 = "903b92d76354366b1d9c4434d0c81643345cef87c1600adfa36095d7b00eede4"
+    source = "https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tgz"
+    source_sha256 = "903b92d76354366b1d9c4434d0c81643345cef87c1600adfa36095d7b00eede4"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tgz"
+    version = "3.8.13"
+  
   [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.8.14:*:*:*:*:*:*:*"
     deprecation_date = "2024-10-01T00:00:00Z"
@@ -70,6 +112,20 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://deps.paketo.io/python/python_3.8.14_linux_x64_bionic_9cb72168.tgz"
     version = "3.8.14"
+  
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.8.14:*:*:*:*:*:*:*"
+    deprecation_date = "2024-10-01T00:00:00Z"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.8.14?checksum=41f959c480c59211feb55d5a28851a56c7e22d02ef91035606ebb21011723c31&download_url=https://www.python.org/ftp/python/3.8.14/Python-3.8.14.tgz"
+    sha256 = "41f959c480c59211feb55d5a28851a56c7e22d02ef91035606ebb21011723c31"
+    source = "https://www.python.org/ftp/python/3.8.14/Python-3.8.14.tgz"
+    source_sha256 = "41f959c480c59211feb55d5a28851a56c7e22d02ef91035606ebb21011723c31"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.8.14/Python-3.8.14.tgz"
+    version = "3.8.14"
 
   [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.9.12:*:*:*:*:*:*:*"
@@ -82,6 +138,20 @@ api = "0.7"
     source_sha256 = "70e08462ebf265012bd2be88a63d2149d880c73e53f1712b7bbbe93750560ae8"
     stacks = ["io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/python/python_3.9.12_linux_x64_jammy_790ed32a.tgz"
+    version = "3.9.12"
+  
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.9.12:*:*:*:*:*:*:*"
+    deprecation_date = "2025-10-01T00:00:00Z"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.9.12?checksum=70e08462ebf265012bd2be88a63d2149d880c73e53f1712b7bbbe93750560ae8&download_url=https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tgz"
+    sha256 = "70e08462ebf265012bd2be88a63d2149d880c73e53f1712b7bbbe93750560ae8"
+    source = "https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tgz"
+    source_sha256 = "70e08462ebf265012bd2be88a63d2149d880c73e53f1712b7bbbe93750560ae8"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tgz"
     version = "3.9.12"
 
   [[metadata.dependencies]]
@@ -112,6 +182,20 @@ api = "0.7"
     version = "3.9.13"
 
   [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.9.13:*:*:*:*:*:*:*"
+    deprecation_date = "2025-10-01T00:00:00Z"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.9.13?checksum=829b0d26072a44689a6b0810f5b4a3933ee2a0b8a4bfc99d7c5893ffd4f97c44&download_url=https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz"
+    sha256 = "829b0d26072a44689a6b0810f5b4a3933ee2a0b8a4bfc99d7c5893ffd4f97c44"
+    source = "https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz"
+    source_sha256 = "829b0d26072a44689a6b0810f5b4a3933ee2a0b8a4bfc99d7c5893ffd4f97c44"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz"
+    version = "3.9.13"
+
+  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.9.14:*:*:*:*:*:*:*"
     deprecation_date = "2025-10-01T00:00:00Z"
     id = "python"
@@ -139,6 +223,19 @@ api = "0.7"
     version = "3.9.14"
 
   [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.9.14:*:*:*:*:*:*:*"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.9.14?checksum=9201836e2c16361b2b7408680502393737d44f227333fe2e5729c7d5f6041675&download_url=https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tgz"
+    sha256 = "9201836e2c16361b2b7408680502393737d44f227333fe2e5729c7d5f6041675"
+    source = "https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tgz"
+    source_sha256 = "9201836e2c16361b2b7408680502393737d44f227333fe2e5729c7d5f6041675"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tgz"
+    version = "3.9.14"
+  
+  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.10.5:*:*:*:*:*:*:*"
     id = "python"
     licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
@@ -149,6 +246,20 @@ api = "0.7"
     source_sha256 = "18f57182a2de3b0be76dfc39fdcfd28156bb6dd23e5f08696f7492e9e3d0bf2d"
     stacks = ["io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/python/python_3.10.5_linux_x64_jammy_0864d6e0.tgz"
+    version = "3.10.5"
+
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.10.5:*:*:*:*:*:*:*"
+    deprecation_date = "2026-10-01T00:00:00Z"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.10.5?checksum=18f57182a2de3b0be76dfc39fdcfd28156bb6dd23e5f08696f7492e9e3d0bf2d&download_url=https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tgz"
+    sha256 = "18f57182a2de3b0be76dfc39fdcfd28156bb6dd23e5f08696f7492e9e3d0bf2d"
+    source = "https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tgz"
+    source_sha256 = "18f57182a2de3b0be76dfc39fdcfd28156bb6dd23e5f08696f7492e9e3d0bf2d"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tgz"
     version = "3.10.5"
 
   [[metadata.dependencies]]
@@ -179,6 +290,19 @@ api = "0.7"
     version = "3.10.6"
 
   [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.10.6:*:*:*:*:*:*:*"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.10.6?checksum=848cb06a5caa85da5c45bd7a9221bb821e33fc2bdcba088c127c58fad44e6343&download_url=https://www.python.org/ftp/python/3.10.6/Python-3.10.6.tgz"
+    sha256 = "848cb06a5caa85da5c45bd7a9221bb821e33fc2bdcba088c127c58fad44e6343"
+    source = "https://www.python.org/ftp/python/3.10.6/Python-3.10.6.tgz"
+    source_sha256 = "848cb06a5caa85da5c45bd7a9221bb821e33fc2bdcba088c127c58fad44e6343"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.10.6/Python-3.10.6.tgz"
+    version = "3.10.6"
+  
+  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:python:python:3.10.7:*:*:*:*:*:*:*"
     deprecation_date = "2026-10-01T00:00:00Z"
     id = "python"
@@ -205,6 +329,19 @@ api = "0.7"
     uri = "https://deps.paketo.io/python/python_3.10.7_linux_x64_jammy_5835bf95.tgz"
     version = "3.10.7"
 
+  [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:python:python:3.10.7:*:*:*:*:*:*:*"
+    id = "python"
+    licenses = ["0BSD", "CNRI-Python-GPL-Compatible"]
+    name = "Python"
+    purl = "pkg:generic/python@3.10.7?checksum=1b2e4e2df697c52d36731666979e648beeda5941d0f95740aafbf4163e5cc126&download_url=https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz"
+    sha256 = "1b2e4e2df697c52d36731666979e648beeda5941d0f95740aafbf4163e5cc126"
+    source = "https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz"
+    source_sha256 = "1b2e4e2df697c52d36731666979e648beeda5941d0f95740aafbf4163e5cc126"
+    stacks = ["*"]
+    uri = "https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz"
+    version = "3.10.7"
+  
   [[metadata.dependency-constraints]]
     constraint = "3.7.*"
     id = "python"
@@ -226,10 +363,4 @@ api = "0.7"
     patches = 2
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "io.buildpacks.stacks.jammy"
-
-[[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"
+  id = "*"

--- a/detect.go
+++ b/detect.go
@@ -26,6 +26,10 @@ type BuildPlanMetadata struct {
 	// used by the consumer of the metadata to determine the priority of this
 	// version request.
 	VersionSource string `toml:"version-source"`
+
+	// ConfigureFlags denotes the configure flags to be requested in the requirements.
+	// This is used to run configure before make and make install.
+	ConfigureFlags string `toml:"configure-flags"`
 }
 
 // Detect will return a packit.DetectFunc that will be invoked during the
@@ -45,12 +49,19 @@ func Detect() packit.DetectFunc {
 		var requirements []packit.BuildPlanRequirement
 
 		if version, ok := os.LookupEnv("BP_CPYTHON_VERSION"); ok {
+			metadata := BuildPlanMetadata{
+				Version:       version,
+				VersionSource: "BP_CPYTHON_VERSION",
+			}
+
+			// Ignored for stacks that do not build python from source
+			if flags, ok := os.LookupEnv("BP_CPYTHON_CONFIGURE_FLAGS"); ok {
+				metadata.ConfigureFlags = flags
+			}
+
 			requirements = append(requirements, packit.BuildPlanRequirement{
-				Name: Cpython,
-				Metadata: BuildPlanMetadata{
-					Version:       version,
-					VersionSource: "BP_CPYTHON_VERSION",
-				},
+				Name:     Cpython,
+				Metadata: metadata,
 			})
 		}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -41,11 +41,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the BP_CPYTHON_VERSION env var is set", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_CPYTHON_VERSION", "some-version")).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_CPYTHON_VERSION")).To(Succeed())
+			t.Setenv("BP_CPYTHON_VERSION", "some-version")
 		})
 
 		it("returns a plan that provides and requires that version of cpython", func() {
@@ -62,6 +58,28 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Metadata: cpython.BuildPlanMetadata{
 							Version:       "some-version",
 							VersionSource: "BP_CPYTHON_VERSION",
+						},
+					},
+				},
+			}))
+		})
+
+		it("returns a plan that provides and requires that version of cpython with configure flags", func() {
+			t.Setenv("BP_CPYTHON_CONFIGURE_FLAGS", "--flag1 --flag2=value")
+			result, err := detect(detectContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: cpython.Cpython},
+				},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: cpython.Cpython,
+						Metadata: cpython.BuildPlanMetadata{
+							Version:        "some-version",
+							VersionSource:  "BP_CPYTHON_VERSION",
+							ConfigureFlags: "--flag1 --flag2=value",
 						},
 					},
 				},

--- a/fakes/dependency_manager.go
+++ b/fakes/dependency_manager.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	packit "github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/postal"
 )
 

--- a/fakes/executable.go
+++ b/fakes/executable.go
@@ -1,0 +1,32 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+)
+
+type Executable struct {
+	ExecuteCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Execution pexec.Execution
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(pexec.Execution) error
+	}
+}
+
+func (f *Executable) Execute(param1 pexec.Execution) error {
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
+	f.ExecuteCall.CallCount++
+	f.ExecuteCall.Receives.Execution = param1
+	if f.ExecuteCall.Stub != nil {
+		return f.ExecuteCall.Stub(param1)
+	}
+	return f.ExecuteCall.Returns.Error
+}

--- a/fakes/installer.go
+++ b/fakes/installer.go
@@ -1,0 +1,41 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/postal"
+)
+
+type PythonInstaller struct {
+	InstallCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			SourcePath string
+			WorkingDir string
+			Entry      packit.BuildpackPlanEntry
+			Dependency postal.Dependency
+			LayerPath  string
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(string, string, packit.BuildpackPlanEntry, postal.Dependency, string) error
+	}
+}
+
+func (f *PythonInstaller) Install(param1 string, param2 string, param3 packit.BuildpackPlanEntry, param4 postal.Dependency, param5 string) error {
+	f.InstallCall.mutex.Lock()
+	defer f.InstallCall.mutex.Unlock()
+	f.InstallCall.CallCount++
+	f.InstallCall.Receives.SourcePath = param1
+	f.InstallCall.Receives.WorkingDir = param2
+	f.InstallCall.Receives.Entry = param3
+	f.InstallCall.Receives.Dependency = param4
+	f.InstallCall.Receives.LayerPath = param5
+	if f.InstallCall.Stub != nil {
+		return f.InstallCall.Stub(param1, param2, param3, param4, param5)
+	}
+	return f.InstallCall.Returns.Error
+}

--- a/init_test.go
+++ b/init_test.go
@@ -11,5 +11,6 @@ func TestUnitPython(t *testing.T) {
 	suite := spec.New("python", spec.Report(report.Terminal{}), spec.Sequential())
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
+	suite("CPythonInstaller", testCPythonInstaller)
 	suite.Run(t)
 }

--- a/installer.go
+++ b/installer.go
@@ -1,0 +1,142 @@
+package cpython
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+	"github.com/paketo-buildpacks/packit/v2/postal"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+)
+
+//go:generate faux --interface Executable --output fakes/executable.go
+
+// CPythonInstaller implements the PythonInstaller interface.
+type CPythonInstaller struct {
+	configureProcess Executable
+	makeProcess      Executable
+	logger           scribe.Emitter
+}
+
+// NewCPythonInstaller creates an instance of the CPythonInstaller given a scribe.Emitter.
+func NewCPythonInstaller(
+	configureProcess Executable,
+	makeProcess Executable,
+	logger scribe.Emitter,
+) CPythonInstaller {
+	return CPythonInstaller{
+		configureProcess: configureProcess,
+		makeProcess:      makeProcess,
+		logger:           logger,
+	}
+}
+
+// Executable defines the interface for invoking an executable.
+type Executable interface {
+	Execute(pexec.Execution) error
+}
+
+// Installs python from source code located in the given sourcePath into the layer path designated by layerPath.
+func (i CPythonInstaller) Install(
+	sourcePath string,
+	workingDir string,
+	entry packit.BuildpackPlanEntry,
+	dependency postal.Dependency,
+	layerPath string,
+) error {
+	flags, _ := entry.Metadata["configure-flags"].(string)
+
+	if flags == "" {
+		flags = "--enable-optimizations --with-ensurepip"
+		i.logger.Debug.Subprocess("Using default configure flags: %v\n", flags)
+	}
+
+	whiteSpace := regexp.MustCompile(`\s+`)
+	configureFlags := whiteSpace.Split(flags, -1)
+	configureFlags = append(configureFlags, "--prefix="+layerPath)
+
+	if err := os.Chdir(sourcePath); err != nil {
+		return err
+	}
+
+	i.logger.Debug.Subprocess("Running 'configure %s'", strings.Join(configureFlags, " "))
+	err := i.configureProcess.Execute(pexec.Execution{
+		Args: configureFlags,
+		// Update PATH so configure executable will be found
+		Env:    environWithUpdatedPath(sourcePath),
+		Stdout: i.logger.Debug.ActionWriter,
+		Stderr: i.logger.Debug.ActionWriter,
+	})
+	if err != nil {
+		i.logger.Subprocess("configure failed. Run with --env BP_LOG_LEVEL=DEBUG to see more information")
+		return err
+	}
+
+	makeFlags := []string{"-j", fmt.Sprint(runtime.NumCPU()), `LDFLAGS="-Wl,--strip-all"`}
+	i.logger.Debug.Subprocess("Running 'make %s'", strings.Join(makeFlags, " "))
+	err = i.makeProcess.Execute(pexec.Execution{
+		Args: makeFlags,
+		// Update PATH so configure executable will be found
+		Env:    environWithUpdatedPath(sourcePath),
+		Stdout: i.logger.Debug.ActionWriter,
+		Stderr: i.logger.Debug.ActionWriter,
+	})
+	if err != nil {
+		i.logger.Subprocess("make failed. Run with --env BP_LOG_LEVEL=DEBUG to see more information")
+		return err
+	}
+
+	makeInstallFlags := []string{"altinstall"}
+	i.logger.Debug.Subprocess("Running 'make %s'", strings.Join(makeInstallFlags, " "))
+	err = i.makeProcess.Execute(pexec.Execution{
+		Args: makeInstallFlags,
+		// Update PATH so configure executable will be found
+		Env:    environWithUpdatedPath(sourcePath),
+		Stdout: i.logger.Debug.ActionWriter,
+		Stderr: i.logger.Debug.ActionWriter,
+	})
+	if err != nil {
+		i.logger.Subprocess("make install failed. Run with --env BP_LOG_LEVEL=DEBUG to see more information")
+		return err
+	}
+
+	versionList := strings.Split(dependency.Version, ".")
+	major := versionList[0]
+	majorMinor := strings.Join(versionList[:len(versionList)-1], ".")
+
+	if err = os.Chdir(filepath.Join(layerPath, "bin")); err != nil {
+		return err
+	}
+
+	for _, name := range []string{"python", "pip"} {
+		i.logger.Debug.Action("Writing symlink bin/%s", name+major)
+		if err = os.Symlink(name+majorMinor, name+major); err != nil {
+			return err
+		}
+	}
+
+	if err = os.Chdir(workingDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Returns environment variables with customPath inserted at the beginning of PATH
+func environWithUpdatedPath(customPath string) []string {
+	var env []string = nil
+
+	for _, v := range os.Environ() {
+		if strings.HasPrefix(v, "PATH") {
+			env = append(env, "PATH="+customPath+":"+strings.TrimPrefix(v, "PATH="))
+		} else {
+			env = append(env, v)
+		}
+	}
+	return env
+}

--- a/installer_test.go
+++ b/installer_test.go
@@ -1,0 +1,238 @@
+package cpython_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/paketo-buildpacks/cpython"
+	"github.com/paketo-buildpacks/cpython/fakes"
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+	"github.com/paketo-buildpacks/packit/v2/postal"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func testCPythonInstaller(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		sourcePath string
+		layerPath  string
+		workingDir string
+
+		entry      packit.BuildpackPlanEntry
+		dependency postal.Dependency
+
+		configureProcess *fakes.Executable
+		makeProcess      *fakes.Executable
+
+		pythonInstaller cpython.PythonInstaller
+	)
+
+	it.Before(func() {
+		var err error
+
+		sourcePath, err = os.MkdirTemp("", "source")
+		Expect(err).NotTo(HaveOccurred())
+
+		layerPath, err = os.MkdirTemp("", "layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.MkdirAll(filepath.Join(layerPath, "bin"), 0755)).To(Succeed())
+
+		workingDir, err = os.MkdirTemp("", "workingdir")
+		Expect(err).NotTo(HaveOccurred())
+
+		configureProcess = &fakes.Executable{}
+		makeProcess = &fakes.Executable{}
+
+		pythonInstaller = cpython.NewCPythonInstaller(configureProcess, makeProcess, scribe.NewEmitter(bytes.NewBuffer(nil)))
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(sourcePath)).To(Succeed())
+		Expect(os.RemoveAll(layerPath)).To(Succeed())
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
+	context("Execute", func() {
+		var (
+			makeInvocationArgs [][]string
+		)
+
+		it.Before(func() {
+			makeInvocationArgs = [][]string{}
+
+			makeProcess.ExecuteCall.Stub = func(e pexec.Execution) error {
+				makeInvocationArgs = append(makeInvocationArgs, e.Args)
+				return nil
+			}
+		})
+
+		it("runs installation", func() {
+			err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(configureProcess.ExecuteCall.CallCount).To(Equal(1))
+			Expect(configureProcess.ExecuteCall.Receives.Execution).To(MatchFields(IgnoreExtras, Fields{
+				"Args": Equal([]string{
+					"--enable-optimizations",
+					"--with-ensurepip",
+					fmt.Sprintf("--prefix=%s", layerPath),
+				}),
+			}))
+
+			Expect(makeProcess.ExecuteCall.CallCount).To(Equal(2))
+
+			Expect(makeInvocationArgs[0]).To(Equal([]string{
+				"-j",
+				fmt.Sprintf("%d", runtime.NumCPU()),
+				`LDFLAGS="-Wl,--strip-all"`,
+			}))
+
+			Expect(makeInvocationArgs[1]).To(Equal([]string{
+				"altinstall",
+			}))
+		})
+
+		context("when configure flags are provided", func() {
+			it.Before(func() {
+				entry.Metadata = make(map[string]interface{})
+				entry.Metadata["configure-flags"] = "--foo --bar=baz"
+			})
+
+			it("uses the provided flags instead of the default", func() {
+				err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(configureProcess.ExecuteCall.CallCount).To(Equal(1))
+				Expect(configureProcess.ExecuteCall.Receives.Execution).To(MatchFields(IgnoreExtras, Fields{
+					"Args": Equal([]string{
+						"--foo",
+						"--bar=baz",
+						fmt.Sprintf("--prefix=%s", layerPath),
+					}),
+				}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when changing to the source directory fails", func() {
+				it.Before(func() {
+					Expect(os.Chmod(sourcePath, 0000)).To(Succeed())
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError(And(
+						ContainSubstring(sourcePath),
+						ContainSubstring("permission denied"),
+					)))
+				})
+			})
+
+			context("when invoking the configureProcess fails with error", func() {
+				it.Before(func() {
+					configureProcess.ExecuteCall.Returns.Error = errors.New("some configure error")
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError("some configure error"))
+
+				})
+			})
+
+			context("when invoking the make process (first time) fails with error", func() {
+				it.Before(func() {
+					makeProcess.ExecuteCall.Stub = nil
+					makeProcess.ExecuteCall.Returns.Error = errors.New("some make error")
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError("some make error"))
+
+				})
+			})
+
+			context("when invoking the make process (second time) fails with error", func() {
+				var (
+					makeInvocationError error
+				)
+
+				it.Before(func() {
+					makeInvocationError = errors.New("some make error (second invocation)")
+
+					makeInvocationCount := 0
+					makeProcess.ExecuteCall.Stub = func(_ pexec.Execution) error {
+						makeInvocationCount++
+
+						if makeInvocationCount == 1 {
+							return nil
+						}
+						return makeInvocationError
+					}
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError("some make error (second invocation)"))
+
+					Expect(makeProcess.ExecuteCall.CallCount).To(Equal(2))
+				})
+			})
+
+			context("when changing to the layer bin directory fails", func() {
+				it.Before(func() {
+					Expect(os.Chmod(filepath.Join(layerPath, "bin"), 0000)).To(Succeed())
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError(And(
+						ContainSubstring(filepath.Join(layerPath, "bin")),
+						ContainSubstring("permission denied"),
+					)))
+				})
+			})
+
+			context("when creating symlinks fails", func() {
+				it.Before(func() {
+					// 0500 permissions because we need Read (4) + Execute (1)
+					// but not write (2) Execute permissions are required to cd
+					// into the directory
+					Expect(os.Chmod(filepath.Join(layerPath, "bin"), 0500)).To(Succeed())
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError(ContainSubstring("symlink")))
+				})
+			})
+
+			context("when changing back to the working directory fails", func() {
+				it.Before(func() {
+					Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+				})
+
+				it("fails with error", func() {
+					err := pythonInstaller.Install(sourcePath, workingDir, entry, dependency, layerPath)
+					Expect(err).Should(MatchError(And(
+						ContainSubstring(workingDir),
+						ContainSubstring("permission denied"),
+					)))
+				})
+			})
+		})
+	})
+}

--- a/integration.json
+++ b/integration.json
@@ -1,7 +1,8 @@
 {
   "builders": [
     "index.docker.io/paketobuildpacks/builder:buildpackless-base",
-    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
+    "index.docker.io/jericop/amazonlinux-builder:base"
   ],
   "build-plan": "github.com/paketo-community/build-plan"
 }

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -130,6 +130,8 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 				firstContainer  occam.Container
 				secondContainer occam.Container
+
+				otherVersion string
 			)
 
 			source, err = occam.Source(filepath.Join("testdata", "default_app"))
@@ -141,7 +143,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
-				WithEnv(map[string]string{"BP_CPYTHON_VERSION": "3.9.*"}).
+				WithEnv(map[string]string{"BP_CPYTHON_VERSION": defaultVersion}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -162,13 +164,20 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(firstContainer).Should(BeAvailable())
 
+			for _, dependency := range buildpackInfo.Metadata.Dependencies {
+				if dependency.Version != defaultVersion {
+					otherVersion = dependency.Version
+					break
+				}
+			}
+
 			secondImage, _, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
 					settings.Buildpacks.Cpython.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
-				WithEnv(map[string]string{"BP_CPYTHON_VERSION": "3.10.*"}).
+				WithEnv(map[string]string{"BP_CPYTHON_VERSION": otherVersion}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This change adds support for all stacks by adding logic to build python from source based on the builder stack.

* For bionic and jammy stacks there is no change and dependencies will be installed from the dep server.
* For custom stacks (not explicitly defined in buildpack.toml) python will be built and installed from source.
* Unit tests and integration tests have been updated to support the changes and all tests pass.
    * Tests took about 20 minutes to run on an intel macbook pro.
* A public amazonlinux stack and builder were used for testing. The images will remain available and public for future testing.
* Note that offline tests are skipped for custom stacks.
* The tests have been made dynamic by adding `defaultDependency`.

~**NOTE about the `org.cloudfoundry.stacks.cflinuxfs3` stack**~

~I found that this stack is based on bionic so I added it to the list of dependencies satisfied for `io.buildpacks.stacks.bionic`. I have not tested this stack, but I believe it should work.~

## Use Cases
<!-- An explanation of the use cases your change enables -->

This allows the cpython buildpack to be used on non-paketo stacks and builders. While most users will be able to use paketo builders and stacks, there are situations where ubuntu-based stacks will not work for some users. In those cases, they have the ability to create their own stacks and builders.

It is expected that any users that want to build python from source on their own stack and builder will have the necessary packages installed in the build image. [This](https://github.com/jericop/amazonlinux-stack) stack repo and [this](https://github.com/jericop/amazonlinux-builder-buildpackless-base) builder repo are examples and were used to validate this change.

Users can customize how python is configured and installed by setting the `BP_CPYTHON_CONFIGURE_FLAGS` environment variable at build time. Supported flags are documented [here](https://docs.python.org/3/using/configure.html). It is expected that anyone setting this will ensure that the necessary libraries, headers, etc, are available in the build image. This allows users to have fine grained control over how python is configured and installed.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
  * I have reviewed it, but have not signed or submitted anything. 
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
