### PR TITLE
Ensure that integration tests only use dependencies for the specified stack

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -212,7 +212,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 					nonDefaultVersion string
 				)
 
-				for _, dependency := range buildpackInfo.Metadata.Dependencies {
+				for _, dependency := range dependenciesForStack() {
 					if dependency.Version != defaultVersion {
 						nonDefaultVersion = dependency.Version
 						break

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -164,7 +164,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(firstContainer).Should(BeAvailable())
 
-			for _, dependency := range buildpackInfo.Metadata.Dependencies {
+			for _, dependency := range dependenciesForStack() {
 				if dependency.Version != defaultVersion {
 					otherVersion = dependency.Version
 					break


### PR DESCRIPTION
## Summary

This PR fixes the integration tests to ensure it only selects dependencies with the specified stack, or `*` if the stack is unrecognized.

This fixes issues with the tests where sometimes an invalid dependency was picked, resulting in failures or compiling from source when there is a pre-compiled equivalent.

The buildpack is already doing the correct thing; the tests need to be more specific about which dependency they request.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
