### PR TITLE
Set PYTHONPYCACHEPREFIX to /tmp during build phase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ The `BP_CPYTHON_VERSION` variable allows you to specify the version of CPython
 that is installed. (Available versions can be found in the
 [buildpack.toml](./buildpack.toml).)
 
+#### `pack build` flag
+```shell
+pack build my-app --env BP_CPYTHON_VERSION=3.10.*
+```
+
+#### In a [`project.toml`](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
+```toml
+[build]
+  [[build.env]]
+    name = 'BP_CPYTHON_VERSION'
+    value = '3.10.*' # any valid semver constraints (e.g. 3.10.2, 3.*) are acceptable
+```
+
 ### `BP_CPYTHON_CONFIGURE_FLAGS`
 The `BP_CPYTHON_CONFIGURE_FLAGS` variable allows you to specify configure flags
 when python is installed from source. This is only applicable when using custom
@@ -58,19 +71,6 @@ For more detail, set it to `debug`.
 
 For example, when compiling from source, setting `BP_LOG_LEVEL=debug` shows the
 commands and outputs run to build python.
-
-#### `pack build` flag
-```shell
-pack build my-app --env BP_CPYTHON_VERSION=3.10.*
-```
-
-#### In a [`project.toml`](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
-```toml
-[build]
-  [[build.env]]
-    name = 'BP_CPYTHON_VERSION'
-    value = '3.10.*' # any valid semver constraints (e.g. 3.10.2, 3.*) are acceptable
-```
 
 ## Integration
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,35 @@
 The CPython Buildpack provides CPython (reference implementation of Python) 3.
 The buildpack installs CPython onto the `$PATH` which makes it available for
 subsequent buildpacks and in the final running container. It also sets the
-`$PYTHONPATH` environment variable.
+`$PYTHONPATH` environment variable for subsequent buildpacks and launch-time
+processes.
 
 The buildpack is published for consumption at `gcr.io/paketo-buildpacks/cpython` and
 `paketobuildpacks/cpython`.
 
 ## Behavior
+
 This buildpack always participates.
 
-The buildpack will do the following:
-* At build time:
-  - Contributes `cpython` to a layer
-  - Sets the `PYTHONPATH` to the `cpython` layer path.
-  - Adds the newly installed `cpython` bin dir location to `PATH`
-* At run time:
-  - Does nothing
+### Build time
+This buildpack performs the following actions at build time:
+* Contributes `cpython` to a layer - either via a precompiled dependency or by
+  compiling from source.
+* Sets the `PYTHONPYCACHEPREFIX` environment variable to the `/tmp` directory
+  for this and any subsequent buildpacks.
+  * This effectively disables the `__pycache__` directories, in turn enabling
+    reproducible builds.
+  * It can be overridden via standard means (e.g. `pack build --env
+    "PYTHONPYCACHEPREFIX=/some/other/dir"`) if there is a need to keep the
+    `__pycache__` directories in place of reproducible builds.
+* Sets the `PYTHONPATH` to the `cpython` layer path for this and any subsequent
+  buildpacks.
+* Adds the newly installed `cpython` bin dir location to the `PATH`.
+
+### Launch time
+This buildpack does the following at launch time:
+
+* Sets a default value for the `PYTHONPATH` environment variable.
 
 ## Configuration
 
@@ -27,10 +41,11 @@ that is installed. (Available versions can be found in the
 
 ### `BP_CPYTHON_CONFIGURE_FLAGS`
 The `BP_CPYTHON_CONFIGURE_FLAGS` variable allows you to specify configure flags
-when python is installed from source. This is only applicable when using custom 
-stacks. Paketo stacks such as `io.buildpacks.stacks.bionic` install pre-built binaries. 
+when python is installed from source. This is only applicable when using custom
+stacks. Paketo stacks such as `io.buildpacks.stacks.bionic` install pre-built binaries.
 
-* The format is space-separated strings, and they are passed directly to the `cpython` `./configure` process , e.g. `--foo --bar=baz`.
+* The format is space-separated strings, and they are passed directly to the
+  `cpython` `./configure` process , e.g. `--foo --bar=baz`.
 * See [python documentation](https://docs.python.org/3/using/configure.html) for supported flags.
 * Default flags if not specified: `--enable-optimizations --with-ensurepip`
 * Note that default flags are overridden if you specify this environment variable,
@@ -38,8 +53,11 @@ which means you almost certainly want to include the defaults along with any cus
   - e.g. `--enable-optimizations --with-ensurepip --foo --bar=baz`
 
 ### `BP_LOG_LEVEL`
-When using custom stacks that install python from source setting `BP_LOG_LEVEL=DEBUG`
-shows the commands and outputs run to build python.
+The `BP_LOG_LEVEL` flag controls the level of verbosity of the buildpack output logs.
+For more detail, set it to `debug`.
+
+For example, when compiling from source, setting `BP_LOG_LEVEL=debug` shows the
+commands and outputs run to build python.
 
 #### `pack build` flag
 ```shell
@@ -111,3 +129,8 @@ $ ./scripts/unit.sh && ./scripts/integration.sh
 ## Compatibility
 
 This buildpack is currently only supported on linux distributions.
+
+Pre-compiled distributions of Python are provided for the Paketo stacks (i.e.
+`io.buildpacks.stack.jammy` and `io.buildpacks.stacks.bionic`).
+
+Source distributions of Python are provided for all other linux stacks.

--- a/build.go
+++ b/build.go
@@ -198,6 +198,7 @@ func Build(
 			DepKey: dependency.Checksum,
 		}
 
+		cpythonLayer.BuildEnv.Default("PYTHONPYCACHEPREFIX", "/tmp")
 		cpythonLayer.SharedEnv.Default("PYTHONPATH", cpythonLayer.Path)
 		cpythonLayer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "env")}
 

--- a/build_test.go
+++ b/build_test.go
@@ -127,10 +127,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.Name).To(Equal("cpython"))
 		Expect(layer.Path).To(Equal(filepath.Join(layersDir, "cpython")))
 
+		Expect(layer.BuildEnv).To(Equal(packit.Environment{
+			"PYTHONPYCACHEPREFIX.default": "/tmp",
+		}))
 		Expect(layer.SharedEnv).To(Equal(packit.Environment{
 			"PYTHONPATH.default": filepath.Join(layersDir, "cpython"),
 		}))
-		Expect(layer.BuildEnv).To(BeEmpty())
 		Expect(layer.LaunchEnv).To(BeEmpty())
 		Expect(layer.ProcessLaunchEnv).To(BeEmpty())
 
@@ -231,10 +233,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.Name).To(Equal("cpython"))
 		Expect(layer.Path).To(Equal(filepath.Join(layersDir, "cpython")))
 
+		Expect(layer.BuildEnv).To(Equal(packit.Environment{
+			"PYTHONPYCACHEPREFIX.default": "/tmp",
+		}))
 		Expect(layer.SharedEnv).To(Equal(packit.Environment{
 			"PYTHONPATH.default": filepath.Join(layersDir, "cpython"),
 		}))
-		Expect(layer.BuildEnv).To(BeEmpty())
 		Expect(layer.LaunchEnv).To(BeEmpty())
 		Expect(layer.ProcessLaunchEnv).To(BeEmpty())
 

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -92,7 +92,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			))
 			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
-				fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				`    PYTHONPYCACHEPREFIX -> "/tmp"`,
 				"",
 				"  Configuring launch environment",
 				fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
@@ -261,7 +262,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(logs).To(ContainLines(
 					"  Configuring build environment",
-					fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+					fmt.Sprintf(`    PYTHONPATH          -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+					`    PYTHONPYCACHEPREFIX -> "/tmp"`,
 					"",
 					"  Configuring launch environment",
 					fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/cpython"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),


### PR DESCRIPTION
## Summary

This PR enables reproducible builds by discarding the `__pycache__` directories at the end of the build phase for this buildpack and all subsequent buildpacks that depend on this.

This is in contrast to the current behavior of persisting the `__pycache__` directories in each buildpack's layer.

It also updates the README to include this new configuration and various other minor README improvements.

We have not observed any performance issues with this configuration: discarding the `__pycache__` directories at the end of each buildpack's build phase does not seem to impact the performance of any buildpack.

## Background

- The `__pycache__` directories are not reproducible and are effectively opaque to us. We cannot make them reproducible, so discarding them is the only option for reproducible builds.
- The `PYTHONPYCACHEPREFIX` environment variable was chosen to allow users to override it if needed, whereas setting `PYTHONDONTWRITEBYTECODE=true` would have been harder, if not impossible, to allow users to override.
- Setting this environment variable as a build environment on the layer (v.s. e.g. in process via `os.SetEnv()`) means all subsequent buildpacks (e.g. pip, poetry, etc) will have this environment variable set automatically by the lifecycle, rather than having to implement this themselves in each buildpack.
- We only set this environment variable for the build phase (and not the launch phase) to allow users to continue to leverage `__pycache__` directories at launch time if they wish. The current launch-time behavior of defaulting to `$HOME/.pycache` is unchanged.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Use Cases

Enables reproducible builds in this buildpack and some subsequent buildpacks.

Fixes #426 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
