### PR TITLE
Add `OpenSSL` support into `CPython` compilation (and ensure compilation tests check for SSL linking)

### DIFF
--- a/dependency/actions/compile/bionic.Dockerfile
+++ b/dependency/actions/compile/bionic.Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-  apt-get -y install dialog apt-utils libdb-dev libgdbm-dev tk8.6-dev curl && \
+  apt-get -y install dialog apt-utils libdb-dev libgdbm-dev tk8.6-dev curl libssl-dev && \
   apt-get -y --force-yes -d install --reinstall libtcl8.6 libtk8.6 libxss1
 
-COPY entrypoint /entrypoint
+COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dependency/actions/compile/entrypoint.sh
+++ b/dependency/actions/compile/entrypoint.sh
@@ -86,6 +86,7 @@ function main() {
         --with-dbmliborder=bdb:gdbm \
         --with-tcltk-includes="-I/usr/include/tcl8.6" \
         --with-tcltk-libs="-L/usr/lib/x86_64-linux-gnu -ltcl8.6 -L/usr/lib/x86_64-linux-gnu -ltk8.6" \
+        --with-openssl="/usr/" \
         --prefix="${DEST_DIR}" \
         --enable-unicode=ucs4
 

--- a/dependency/actions/compile/jammy.Dockerfile
+++ b/dependency/actions/compile/jammy.Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-  apt-get -y install dialog apt-utils libdb-dev libgdbm-dev tk8.6-dev curl && \
+  apt-get -y install dialog apt-utils libdb-dev libgdbm-dev tk8.6-dev curl libssl-dev && \
   apt-get -y --force-yes -d install --reinstall libtcl8.6 libtk8.6 libxss1
 
-COPY entrypoint /entrypoint
+COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dependency/test/README.md
+++ b/dependency/test/README.md
@@ -1,22 +1,12 @@
 To test locally:
 
 ```shell
-# assume $output_dir is the output from the compilation step, with a tarball and a checksum in it
-
-docker run -it \
-  --volume $output_dir:/tmp/output_dir \
-  --volume $PWD:/tmp/test \
-  ubuntu:jammy \
-  bash
-
-# Now on the container
-# This is not required on Github Actions Virtual Environments
-# https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
-apt-get update && apt-get install curl -y
+# Assume $output_dir is the output from the compilation step, with a tarball and a checksum in it.
+# Note that the wildcard is not quoted, to allow globbing
 
 # Passing
-$ /tmp/test/test.sh \
-  --tarballPath /tmp/output_dir/python_3.10.7_linux_x64_jammy_ad0be19c.tgz \
+$ ./test.sh \
+  --tarballPath ${output_dir}/*.tgz \
   --expectedVersion 3.10.7
 tarballPath=/tmp/output_dir/python_3.10.7_linux_x64_jammy_ad0be19c.tgz
 expectedVersion=3.10.7
@@ -24,7 +14,7 @@ All tests passed!
 
 # Failing
 $ /tmp/test/test.sh \
-  --tarballPath /tmp/output_dir/python_3.10.7_linux_x64_jammy_ad0be19c.tgz \
+  --tarballPath ${output_dir}/*.tgz \
   --expectedVersion 999.999.999
 tarballPath=/tmp/output_dir/python_3.10.7_linux_x64_jammy_ad0be19c.tgz
 expectedVersion=999.999.999

--- a/dependency/test/bionic.Dockerfile
+++ b/dependency/test/bionic.Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get -y install curl openssl
+
+COPY entrypoint.sh /entrypoint.sh
+COPY fixtures /fixtures
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dependency/test/entrypoint.sh
+++ b/dependency/test/entrypoint.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+parent_dir="$(cd "$(dirname "$0")" && pwd)"
+
+extract_tarball() {
+  rm -rf cpython
+  mkdir cpython
+  tar --extract --file "${1}" \
+    --directory cpython
+}
+
+set_ld_library_path() {
+  export LD_LIBRARY_PATH="$PWD/cpython/lib:${LD_LIBRARY_PATH:-}"
+}
+
+check_version() {
+  expected_version="${1}"
+  actual_version="$(./cpython/bin/python3 --version | cut -d' ' -f2)"
+  if [[ "${actual_version}" != "${expected_version}" ]]; then
+    echo "Version ${actual_version} does not match expected version ${expected_version}"
+    exit 1
+  fi
+}
+
+check_server() {
+  set +e
+
+  ./cpython/bin/python3 "/fixtures/server.py" 8080 &
+  server_pid=$!
+
+  succeeded=0
+  for _ in {1..5}; do
+    response="$(curl -s http://localhost:8080)"
+    if [[ $response == *"Hello world!"* ]]; then
+      succeeded=1
+      break
+    fi
+    sleep 1
+  done
+
+  kill "${server_pid}"
+
+  if [[ ${succeeded} -eq 0 ]]; then
+    echo "Failed to curl server"
+    exit 1
+  fi
+
+  set -e
+}
+
+check_ssl() {
+  ./cpython/bin/python3  -c "import ssl; print(ssl.OPENSSL_VERSION)"
+  result=$?
+  if [[ ${result} -ne 0 ]]; then
+    echo "Failed to check for SSL"
+    exit 1
+  fi
+}
+
+main() {
+  local tarballPath expectedVersion
+  tarballPath=""
+  expectedVersion=""
+
+  while [ "${#}" != 0 ]; do
+    case "${1}" in
+      --tarballPath)
+        tarballPath="${2}"
+        shift 2
+        ;;
+
+      --expectedVersion)
+        expectedVersion="${2}"
+        shift 2
+        ;;
+
+      "")
+        shift
+        ;;
+
+      *)
+        echo "unknown argument \"${1}\""
+        exit 1
+    esac
+  done
+
+  if [[ "${tarballPath}" == "" ]]; then
+    echo "--tarballPath is required"
+    exit 1
+  fi
+
+  if [[ "${expectedVersion}" == "" ]]; then
+    echo "--expectedVersion is required"
+    exit 1
+  fi
+
+  echo "Inside image: tarballPath=${tarballPath}"
+  echo "Inside image: expectedVersion=${expectedVersion}"
+
+  extract_tarball "${tarballPath}"
+  set_ld_library_path
+  check_version "${expectedVersion}"
+  check_server
+  check_ssl
+
+  echo "All tests passed!"
+}
+
+main "$@"

--- a/dependency/test/jammy.Dockerfile
+++ b/dependency/test/jammy.Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:jammy
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get -y install curl openssl
+
+COPY entrypoint.sh /entrypoint.sh
+COPY fixtures /fixtures
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fix OpenSSL for CPython compilation
- Add openssl to the compilation image
- Run compilation tests on bionic and jammy
- Check for SSL dynamic linking during compilation tests
