### PR TITLE
Do not enable optimizations by default when compiling python from source

### DIFF
--- a/installer.go
+++ b/installer.go
@@ -52,7 +52,7 @@ func (i CPythonInstaller) Install(
 	flags, _ := entry.Metadata["configure-flags"].(string)
 
 	if flags == "" {
-		flags = "--enable-optimizations --with-ensurepip"
+		flags = "--with-ensurepip"
 		i.logger.Debug.Subprocess("Using default configure flags: %v\n", flags)
 	}
 

--- a/installer_test.go
+++ b/installer_test.go
@@ -85,7 +85,6 @@ func testCPythonInstaller(t *testing.T, context spec.G, it spec.S) {
 			Expect(configureProcess.ExecuteCall.CallCount).To(Equal(1))
 			Expect(configureProcess.ExecuteCall.Receives.Execution).To(MatchFields(IgnoreExtras, Fields{
 				"Args": Equal([]string{
-					"--enable-optimizations",
 					"--with-ensurepip",
 					fmt.Sprintf("--prefix=%s", layerPath),
 				}),


### PR DESCRIPTION
## Summary

This PR removes the `--enable-optimizations` flag from the default set of flags when compiling python from source. This change speeds up the build phase significantly (empirically we see a speed by about 5x). In turn, this speeds up the integration tests noticeably. The tradeoff is that python apps built with this feature are typically about 10-20% slower. Users who want to leverage this buildpack to compile python from source for production usage can add the `--enable-optimizations` flag back in via the `BP_CONFIGURE_FLAGS` environment variable.

Making this the default for source compilation significantly reduces the duration of the integration tests.

This change does not affect the pre-built binaries on the bionic and jammy stacks - just the compilation from source on wildcard (`*`) stacks.

## Use Cases

The primary use-case of this change is to speed up the integration tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
