### PR TITLE
Add required dependencies (libffi-dev) to python compilation.

### DIFF
--- a/dependency/actions/compile/bionic.Dockerfile
+++ b/dependency/actions/compile/bionic.Dockerfile
@@ -3,8 +3,20 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-  apt-get -y install dialog apt-utils libdb-dev libgdbm-dev tk8.6-dev curl libssl-dev && \
-  apt-get -y --force-yes -d install --reinstall libtcl8.6 libtk8.6 libxss1
+  apt-get -y install --no-install-recommends \
+    apt-utils \
+    build-essential \
+    ca-certificates \
+    curl \
+    dialog \
+    libdb-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libssl-dev \
+    tk8.6-dev \
+    tzdata \
+    xz-utils \
+  && apt-get -y --force-yes -d install --reinstall libtcl8.6 libtk8.6 libxss1
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/dependency/actions/compile/jammy.Dockerfile
+++ b/dependency/actions/compile/jammy.Dockerfile
@@ -3,8 +3,20 @@ FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-  apt-get -y install dialog apt-utils libdb-dev libgdbm-dev tk8.6-dev curl libssl-dev && \
-  apt-get -y --force-yes -d install --reinstall libtcl8.6 libtk8.6 libxss1
+  apt-get -y install --no-install-recommends \
+    apt-utils \
+    build-essential \
+    ca-certificates \
+    curl \
+    dialog \
+    libdb-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libssl-dev \
+    tk8.6-dev \
+    tzdata \
+    xz-utils \
+  && apt-get -y --force-yes -d install --no-install-recommends --reinstall libtcl8.6 libtk8.6 libxss1
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
## Summary

This PR fixes the compilation of the python dependencies. The only library that was required was `libffi-dev`.

I added `--no-install-recommends` to keep dependencies to a minimum. This changed required manually adding back in dependencies like `build-essential` and `ca-certificates` that were previously installed as they were 'recommended' dependencies of listed packages.

I have tested this library with all versions of cpython on both jammy and bionic and versions built with this library pass the `pip-install` integration tests and the samples from the samples repository.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
