### PR TITLE
Update README to reflect new default source-compilation flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ stacks. Paketo stacks such as `io.buildpacks.stacks.bionic` install pre-built bi
 * The format is space-separated strings, and they are passed directly to the
   `cpython` `./configure` process , e.g. `--foo --bar=baz`.
 * See [python documentation](https://docs.python.org/3/using/configure.html) for supported flags.
-* Default flags if not specified: `--enable-optimizations --with-ensurepip`
+* Default flags if not specified: `--with-ensurepip`
 * Note that default flags are overridden if you specify this environment variable,
 which means you almost certainly want to include the defaults along with any custom flags.
-  - e.g. `--enable-optimizations --with-ensurepip --foo --bar=baz`
+  - e.g. `--with-ensurepip --foo --bar=baz`
 
 ### `BP_LOG_LEVEL`
 The `BP_LOG_LEVEL` flag controls the level of verbosity of the buildpack output logs.


### PR DESCRIPTION
## Summary

In #466 we removed the `--enable-optimizations` flag from the source compilation. This PR updates the README to match those defaults.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
