### PR TITLE
Add libsqlite3-dev dependency to python compilation

### DIFF
--- a/dependency/actions/compile/bionic.Dockerfile
+++ b/dependency/actions/compile/bionic.Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     libgdbm-dev \
     liblzma-dev \
     libreadline-dev \
+    libsqlite3-dev \
     libssl-dev \
     ncurses-dev \
     tk8.6-dev \

--- a/dependency/actions/compile/jammy.Dockerfile
+++ b/dependency/actions/compile/jammy.Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     libgdbm-dev \
     liblzma-dev \
     libreadline-dev \
+    libsqlite3-dev \
     libssl-dev \
     ncurses-dev \
     tk8.6-dev \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Installs libsqlite3-dev on builders used for compiling Python used as pre-builds for the cpython buildpack.

This solves an issue where the `sqlite3` module can not be imported since the `_sqlite3` module is not being provided if the corresponding libraries are not available at install time.

## Use Cases

This fixes use cases where a Python application might try to use the included [`sqlite3` library](https://docs.python.org/3/library/sqlite3.html).

## Example

**1. Compiled Python using the builder as detailed in the [compile Action README](https://github.com/paketo-buildpacks/cpython/blob/main/dependency/actions/compile/README.md).**

**2. Running a python prompt built without this change:**

```
@matthiaswenz ➜ /workspaces/bionic/python_sans_sqlite $ LD_LIBRARY_PATH=./lib bin/python3
Python 3.10.7 (main, Dec  2 2022, 17:14:18) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sqlite3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/bionic/python_sans_sqlite/lib/python3.10/sqlite3/__init__.py", line 57, in <module>
    from sqlite3.dbapi2 import *
  File "/workspaces/bionic/python_sans_sqlite/lib/python3.10/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ModuleNotFoundError: No module named '_sqlite3'
``` 

<details><summary>Detailed list of modules available in python</summary>

```
@matthiaswenz ➜ /workspaces/bionic/python_sans_sqlite $ LD_LIBRARY_PATH=./lib bin/python3
Python 3.10.7 (main, Dec  2 2022, 17:14:18) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sqlite3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/bionic/python_sans_sqlite/lib/python3.10/sqlite3/__init__.py", line 57, in <module>
    from sqlite3.dbapi2 import *
  File "/workspaces/bionic/python_sans_sqlite/lib/python3.10/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ModuleNotFoundError: No module named '_sqlite3'
>>> help('modules')

Please wait a moment while I gather a list of all available modules...

/workspaces/bionic/python_sans_sqlite/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
__future__          _testmultiphase     gettext             sched
_abc                _thread             glob                secrets
_aix_support        _threading_local    graphlib            select
_ast                _tkinter            grp                 selectors
_asyncio            _tracemalloc        gzip                setuptools
_bisect             _warnings           hashlib             shelve
_blake2             _weakref            heapq               shlex
_bootsubprocess     _weakrefset         hmac                shutil
_bz2                _xxsubinterpreters  html                signal
_codecs             _xxtestfuzz         http                site
_codecs_cn          _zoneinfo           idlelib             smtpd
_codecs_hk          abc                 imaplib             smtplib
_codecs_iso2022     aifc                imghdr              sndhdr
_codecs_jp          antigravity         imp                 socket
_codecs_kr          argparse            importlib           socketserver
_codecs_tw          array               inspect             spwd
_collections        ast                 io                  sqlite3
_collections_abc    asynchat            ipaddress           sre_compile
_compat_pickle      asyncio             itertools           sre_constants
_compression        asyncore            json                sre_parse
_contextvars        atexit              keyword             ssl
_crypt              audioop             lib2to3             stat
_csv                base64              linecache           statistics
_ctypes             bdb                 locale              string
_ctypes_test        binascii            logging             stringprep
_curses             binhex              lzma                struct
_curses_panel       bisect              mailbox             subprocess
_datetime           builtins            mailcap             sunau
_dbm                bz2                 marshal             symtable
_decimal            cProfile            math                sys
_distutils_hack     calendar            mimetypes           sysconfig
_elementtree        cgi                 mmap                syslog
_functools          cgitb               modulefinder        tabnanny
_gdbm               chunk               multiprocessing     tarfile
_hashlib            cmath               netrc               telnetlib
_heapq              cmd                 nis                 tempfile
_imp                code                nntplib             termios
_io                 codecs              ntpath              test
_json               codeop              nturl2path          textwrap
_locale             collections         numbers             this
_lsprof             colorsys            opcode              threading
_lzma               compileall          operator            time
_markupbase         concurrent          optparse            timeit
_md5                configparser        os                  tkinter
_multibytecodec     contextlib          ossaudiodev         token
_multiprocessing    contextvars         pathlib             tokenize
_opcode             copy                pdb                 trace
_operator           copyreg             pickle              traceback
_osx_support        crypt               pickletools         tracemalloc
_pickle             csv                 pip                 tty
_posixshmem         ctypes              pipes               turtle
_posixsubprocess    curses              pkg_resources       turtledemo
_py_abc             dataclasses         pkgutil             types
_pydecimal          datetime            platform            typing
_pyio               dbm                 plistlib            unicodedata
_queue              decimal             poplib              unittest
_random             difflib             posix               urllib
_sha1               dis                 posixpath           uu
_sha256             distutils           pprint              uuid
_sha3               doctest             profile             venv
_sha512             email               pstats              warnings
_signal             encodings           pty                 wave
_sitebuiltins       ensurepip           pwd                 weakref
_socket             enum                py_compile          webbrowser
_sre                errno               pyclbr              wsgiref
_ssl                faulthandler        pydoc               xdrlib
_stat               fcntl               pydoc_data          xml
_statistics         filecmp             pyexpat             xmlrpc
_string             fileinput           queue               xxlimited
_strptime           fnmatch             quopri              xxlimited_35
_struct             fractions           random              xxsubtype
_symtable           ftplib              re                  zipapp
_sysconfigdata__linux_x86_64-linux-gnu functools           readline            zipfile
_testbuffer         gc                  reprlib             zipimport
_testcapi           genericpath         resource            zlib
_testimportmultiple getopt              rlcompleter         zoneinfo
_testinternalcapi   getpass             runpy               

Enter any module name to get more help.  Or, type "modules spam" to search
for modules whose name or summary contain the string "spam".

>>> 
```

</details>

**3. Running a python prompt built with this change:**

```
@matthiaswenz ➜ /workspaces/bionic/python_with_sqlite $ LD_LIBRARY_PATH=./lib bin/python3
Python 3.10.7 (main, Dec  2 2022, 17:20:58) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sqlite3
>>>
```

<details><summary>Detailed list of modules available in python</summary>

```
@matthiaswenz ➜ /workspaces/bionic/python_with_sqlite $ LD_LIBRARY_PATH=./lib bin/python3
Python 3.10.7 (main, Dec  2 2022, 17:20:58) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sqlite3
>>> help('modules')

Please wait a moment while I gather a list of all available modules...

/workspaces/bionic/python_with_sqlite/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
__future__          _testinternalcapi   getpass             runpy
_abc                _testmultiphase     gettext             sched
_aix_support        _thread             glob                secrets
_ast                _threading_local    graphlib            select
_asyncio            _tkinter            grp                 selectors
_bisect             _tracemalloc        gzip                setuptools
_blake2             _warnings           hashlib             shelve
_bootsubprocess     _weakref            heapq               shlex
_bz2                _weakrefset         hmac                shutil
_codecs             _xxsubinterpreters  html                signal
_codecs_cn          _xxtestfuzz         http                site
_codecs_hk          _zoneinfo           idlelib             smtpd
_codecs_iso2022     abc                 imaplib             smtplib
_codecs_jp          aifc                imghdr              sndhdr
_codecs_kr          antigravity         imp                 socket
_codecs_tw          argparse            importlib           socketserver
_collections        array               inspect             spwd
_collections_abc    ast                 io                  sqlite3
_compat_pickle      asynchat            ipaddress           sre_compile
_compression        asyncio             itertools           sre_constants
_contextvars        asyncore            json                sre_parse
_crypt              atexit              keyword             ssl
_csv                audioop             lib2to3             stat
_ctypes             base64              linecache           statistics
_ctypes_test        bdb                 locale              string
_curses             binascii            logging             stringprep
_curses_panel       binhex              lzma                struct
_datetime           bisect              mailbox             subprocess
_dbm                builtins            mailcap             sunau
_decimal            bz2                 marshal             symtable
_distutils_hack     cProfile            math                sys
_elementtree        calendar            mimetypes           sysconfig
_functools          cgi                 mmap                syslog
_gdbm               cgitb               modulefinder        tabnanny
_hashlib            chunk               multiprocessing     tarfile
_heapq              cmath               netrc               telnetlib
_imp                cmd                 nis                 tempfile
_io                 code                nntplib             termios
_json               codecs              ntpath              test
_locale             codeop              nturl2path          textwrap
_lsprof             collections         numbers             this
_lzma               colorsys            opcode              threading
_markupbase         compileall          operator            time
_md5                concurrent          optparse            timeit
_multibytecodec     configparser        os                  tkinter
_multiprocessing    contextlib          ossaudiodev         token
_opcode             contextvars         pathlib             tokenize
_operator           copy                pdb                 trace
_osx_support        copyreg             pickle              traceback
_pickle             crypt               pickletools         tracemalloc
_posixshmem         csv                 pip                 tty
_posixsubprocess    ctypes              pipes               turtle
_py_abc             curses              pkg_resources       turtledemo
_pydecimal          dataclasses         pkgutil             types
_pyio               datetime            platform            typing
_queue              dbm                 plistlib            unicodedata
_random             decimal             poplib              unittest
_sha1               difflib             posix               urllib
_sha256             dis                 posixpath           uu
_sha3               distutils           pprint              uuid
_sha512             doctest             profile             venv
_signal             email               pstats              warnings
_sitebuiltins       encodings           pty                 wave
_socket             ensurepip           pwd                 weakref
_sqlite3            enum                py_compile          webbrowser
_sre                errno               pyclbr              wsgiref
_ssl                faulthandler        pydoc               xdrlib
_stat               fcntl               pydoc_data          xml
_statistics         filecmp             pyexpat             xmlrpc
_string             fileinput           queue               xxlimited
_strptime           fnmatch             quopri              xxlimited_35
_struct             fractions           random              xxsubtype
_symtable           ftplib              re                  zipapp
_sysconfigdata__linux_x86_64-linux-gnu functools           readline            zipfile
_testbuffer         gc                  reprlib             zipimport
_testcapi           genericpath         resource            zlib
_testimportmultiple getopt              rlcompleter         zoneinfo

Enter any module name to get more help.  Or, type "modules spam" to search
for modules whose name or summary contain the string "spam".

>>> 
```

</details>


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
