### PR TITLE
Remove unused syncignore

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,2 +1,3 @@
 CODEOWNERS
-workflows/update-dependencies.yml
+scripts/remove-source-deps
+scripts/remove_source_deps_overlay.yml

--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,3 +1,1 @@
 CODEOWNERS
-scripts/remove-source-deps
-scripts/remove_source_deps_overlay.yml


### PR DESCRIPTION
## Summary

This PR removes an unused entry from `.syncignore`. It was left over from when we refactored github workflows.

## Use Cases

Clean up technical debt.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
