### PR TITLE
Default StripComponents if not user-provided

### DIFF
--- a/build.go
+++ b/build.go
@@ -138,8 +138,10 @@ func Build(
 		if dependency.URI == dependency.Source {
 			sourcePath := filepath.Join(cpythonLayer.Path, "python-source")
 
-			// CPython distributions have one layer of directory prefix, so strip that when unpacking
-			dependency.StripComponents = 1
+			if dependency.StripComponents == 0 {
+				// CPython distributions have one layer of directory prefix, so strip that when unpacking
+				dependency.StripComponents = 1
+			}
 
 			err = os.Mkdir(sourcePath, 0755)
 			if err != nil {


### PR DESCRIPTION
Users want to re-use this buildpack logic with their own CPython distributions.  Support using CPython distributions that may require more than 1 component stripped.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
If the user has not provided a value for `StripComponents`, then use the default for the Paketo CPyhton distribution.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Organizations often have internal CPython distributions.  An organization with a CPython distribution with one or more prefix components can now re-use this buildpack logic.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
