### PR TITLE
Optionally remove setuptools using BP_CPYTHON_RM_SETUPTOOLS env var

### DIFF
--- a/fakes/pip_cleanup.go
+++ b/fakes/pip_cleanup.go
@@ -1,0 +1,30 @@
+package fakes
+
+import "sync"
+
+type PythonPipCleanup struct {
+	CleanupCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Packages    []string
+			TargetLayer string
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func([]string, string) error
+	}
+}
+
+func (f *PythonPipCleanup) Cleanup(param1 []string, param2 string) error {
+	f.CleanupCall.mutex.Lock()
+	defer f.CleanupCall.mutex.Unlock()
+	f.CleanupCall.CallCount++
+	f.CleanupCall.Receives.Packages = param1
+	f.CleanupCall.Receives.TargetLayer = param2
+	if f.CleanupCall.Stub != nil {
+		return f.CleanupCall.Stub(param1, param2)
+	}
+	return f.CleanupCall.Returns.Error
+}

--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitPython(t *testing.T) {
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
 	suite("CPythonInstaller", testCPythonInstaller)
+	suite("PipCleanup", testPipCleanup)
 	suite.Run(t)
 }

--- a/pip_cleanup.go
+++ b/pip_cleanup.go
@@ -1,0 +1,74 @@
+package cpython
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+)
+
+// This function serves as a constant for packages to be uninstalled
+func pipPackagesToBeUninstalled() []string {
+	return []string{"setuptools"}
+}
+
+// PipCleanup implements the PythonPipCleanup interface.
+type PipCleanup struct {
+	pythonProcess Executable
+	logger        scribe.Emitter
+}
+
+// NewPipCleanup creates an instance of PipCleanup given a python Executable and a scribe.Emitter.
+func NewPipCleanup(pythonProcess Executable, logger scribe.Emitter) PipCleanup {
+	return PipCleanup{
+		pythonProcess: pythonProcess,
+		logger:        logger,
+	}
+}
+
+func (i PipCleanup) Cleanup(packages []string, targetLayer string) error {
+	env := environWithUpdatedPath(os.Environ(), "PATH", filepath.Join(targetLayer, "bin"))
+	env = environWithUpdatedPath(env, "LD_LIBRARY_PATH", filepath.Join(targetLayer, "lib"))
+
+	if len(packages) > 0 {
+		// Verify pip --version works to ensure subsequent pip commands will work
+		err := i.pythonProcess.Execute(pexec.Execution{
+			Args:   []string{"-m", "pip", "--version"},
+			Env:    env,
+			Stdout: i.logger.Debug.ActionWriter,
+			Stderr: i.logger.Debug.ActionWriter,
+		})
+		if err != nil {
+			i.logger.Subprocess("pip --version failed. Run with --env BP_LOG_LEVEL=DEBUG to see more information")
+			return err
+		}
+
+		// Remove packages from site-packages in the targetLayer
+		for _, name := range packages {
+			i.logger.Debug.Subprocess("Checking if '%s' package is installed", name)
+			err := i.pythonProcess.Execute(pexec.Execution{
+				Args:   []string{"-m", "pip", "show", "-q", name},
+				Env:    env,
+				Stdout: i.logger.Debug.ActionWriter,
+				Stderr: i.logger.Debug.ActionWriter,
+			})
+
+			if err == nil {
+				i.logger.Debug.Subprocess("Uninstalling '%s' package", name)
+				err = i.pythonProcess.Execute(pexec.Execution{
+					Args:   []string{"-m", "pip", "uninstall", "-y", name},
+					Env:    env,
+					Stdout: i.logger.Debug.ActionWriter,
+					Stderr: i.logger.Debug.ActionWriter,
+				})
+				if err != nil {
+					i.logger.Subprocess("pip uninstall failed. Run with --env BP_LOG_LEVEL=DEBUG to see more information")
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pip_cleanup_test.go
+++ b/pip_cleanup_test.go
@@ -1,0 +1,134 @@
+package cpython_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/paketo-buildpacks/cpython"
+	"github.com/paketo-buildpacks/cpython/fakes"
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testPipCleanup(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		layerPath     string
+		pythonProcess *fakes.Executable
+		pipCleanup    cpython.PythonPipCleanup
+	)
+
+	it.Before(func() {
+		pythonProcess = &fakes.Executable{}
+
+		pipCleanup = cpython.NewPipCleanup(pythonProcess, scribe.NewEmitter(bytes.NewBuffer(nil)))
+	})
+
+	context("Execute", func() {
+		var (
+			pythonInvocationArgs [][]string
+			packages             []string
+		)
+
+		it.Before(func() {
+			pythonInvocationArgs = [][]string{}
+			packages = []string{}
+
+			pythonProcess.ExecuteCall.Stub = func(e pexec.Execution) error {
+				pythonInvocationArgs = append(pythonInvocationArgs, e.Args)
+				return nil
+			}
+		})
+
+		context("when packages are installed", func() {
+			it.Before(func() {
+				packages = []string{"somepkg"}
+			})
+
+			it("uninstalls packages", func() {
+				err := pipCleanup.Cleanup(packages, layerPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(pythonProcess.ExecuteCall.CallCount).To(Equal(3))
+				Expect(pythonInvocationArgs[0]).To(Equal([]string{"-m", "pip", "--version"}))
+				Expect(pythonInvocationArgs[1]).To(Equal([]string{"-m", "pip", "show", "-q", packages[0]}))
+				Expect(pythonInvocationArgs[2]).To(Equal([]string{"-m", "pip", "uninstall", "-y", packages[0]}))
+			})
+		})
+
+		context("when packages are not installed", func() {
+			it.Before(func() {
+				packages = []string{"somepkg-that-does-not-exist"}
+
+				pythonProcess.ExecuteCall.Stub = func(e pexec.Execution) error {
+					pythonInvocationArgs = append(pythonInvocationArgs, e.Args)
+					if e.Args[2] == "show" {
+						return errors.New("pip package not found")
+					}
+					return nil
+				}
+			})
+
+			it("does not uninstall packages", func() {
+				err := pipCleanup.Cleanup(packages, layerPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(pythonProcess.ExecuteCall.CallCount).To(Equal(2))
+				Expect(pythonInvocationArgs[0]).To(Equal([]string{"-m", "pip", "--version"}))
+				Expect(pythonInvocationArgs[1]).To(Equal([]string{"-m", "pip", "show", "-q", packages[0]}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when pip version returns an error", func() {
+				it.Before(func() {
+					packages = []string{"somepkg"}
+
+					pythonProcess.ExecuteCall.Stub = func(e pexec.Execution) error {
+						pythonInvocationArgs = append(pythonInvocationArgs, e.Args)
+						return errors.New("pip is broken")
+					}
+				})
+
+				it("fails with error", func() {
+					err := pipCleanup.Cleanup(packages, layerPath)
+					Expect(err).Should(MatchError(And(
+						ContainSubstring("pip is broken"),
+					)))
+					Expect(pythonProcess.ExecuteCall.CallCount).To(Equal(1))
+					Expect(pythonInvocationArgs[0]).To(Equal([]string{"-m", "pip", "--version"}))
+				})
+			})
+
+			context("when pip uninstall returns an error", func() {
+				it.Before(func() {
+					packages = []string{"somepkg"}
+
+					pythonProcess.ExecuteCall.Stub = func(e pexec.Execution) error {
+						pythonInvocationArgs = append(pythonInvocationArgs, e.Args)
+						if e.Args[2] == "uninstall" {
+							return errors.New("failed to uninstall pip package")
+						}
+						return nil
+					}
+				})
+
+				it("fails with error", func() {
+					err := pipCleanup.Cleanup(packages, layerPath)
+					Expect(err).Should(MatchError(And(
+						ContainSubstring("failed to uninstall pip package"),
+					)))
+					Expect(pythonProcess.ExecuteCall.CallCount).To(Equal(3))
+					Expect(pythonInvocationArgs[0]).To(Equal([]string{"-m", "pip", "--version"}))
+					Expect(pythonInvocationArgs[1]).To(Equal([]string{"-m", "pip", "show", "-q", packages[0]}))
+					Expect(pythonInvocationArgs[2]).To(Equal([]string{"-m", "pip", "uninstall", "-y", packages[0]}))
+				})
+			})
+		})
+	})
+}

--- a/run/main.go
+++ b/run/main.go
@@ -27,6 +27,10 @@ func main() {
 		pexec.NewExecutable("make"),
 		logger,
 	)
+	pipCleanup := cpython.NewPipCleanup(
+		pexec.NewExecutable("python3"),
+		logger,
+	)
 	sbomGenerator := Generator{}
 
 	packit.Run(
@@ -34,6 +38,7 @@ func main() {
 		cpython.Build(
 			dependencies,
 			pythonSourceInstaller,
+			pipCleanup,
 			sbomGenerator,
 			logger,
 			chronos.DefaultClock),


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change addresses https://github.com/paketo-buildpacks/cpython/issues/579 and also cleans up broken pip executables in the cpython layer. The main issue is that the current pre-compiled installations of python include the `setuptools` package which has a known vulnerability. This change removes that package.

More reasons why this is helpful:
* Who is to say that future versions of `setuptools` in newer python releases don't suffer from the same thing. This change would just remove `setuptools` always to avoid the issue entirely.
* It removes unnecessary files because it is likely that end-users install their own version of `setuptools` for their own app dependencies. Today you end up with 2 versions of `setuptools` in your app image, but you really only need the one you intended to install with other dependencies.

### Current workaround

When upgrading is not an option, my current workaround is to add a project.toml file with an inline build pack to remove the offending setuptools package. In the words of a fellow engineer, "YUCK." This is the last thing I want to do or encourage users to do.

## Use Cases
The issue has a lot of good information in it and rightly encourages users to upgrade to a new version of python. Unfortunately this is not always an option, so this change adds a way to remove packages from the python site-packages folder in the layer as needed. It also checks for and removes broken pip executables from the installation if there are any.

The PipCleanup function will do nothing if `setuptools` is not installed. It will also do nothing if there are no broken pip executables.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
