### PR TITLE
Revert "Add targets to buildpack.toml"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -458,11 +458,3 @@ api = "0.7"
 
 [[stacks]]
   id = "*"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "18.04"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "22.04"


### PR DESCRIPTION
This reverts commit 0940a29ae550094172b28c7bb57860e56c212db2.

 - This change was made in error. We can re-evaluate introducing targets when we bump the buildpack API spec.
